### PR TITLE
Patch to fix issue php 7.1 issue 2910966

### DIFF
--- a/service_views-reference-php7.1-issue-2910966.patch
+++ b/service_views-reference-php7.1-issue-2910966.patch
@@ -1,0 +1,13 @@
+diff --git a/services_views.resource.inc b/services_views.resource.inc
+index a534eb3..e9967e5 100755
+--- a/services_views.resource.inc
++++ b/services_views.resource.inc
+@@ -169,7 +169,7 @@ function services_views_execute_view($view_info, $view = NULL, $display_id = NUL
+         // Create helper variables
+         $output[$index]->$target_key = array();
+         if($field->field_info['cardinality'] == 1)
+-          $output[$index]->$target_key = '';
++          $output[$index]->$target_key[] = '';
+         $obj = &$output[$index]->$target_key;
+         $format = ($field->options['type'] == 'services') ? 'raw' : 'rendered';
+


### PR DESCRIPTION
https://www.drupal.org/project/services_views/issues/2910966

When using Services views running on php 7.1 node title and text fields only return the first character, text area are empty.
I am using the plain text formatter for all text fields and text area's.

